### PR TITLE
Add public functions to get time and value of a DataPoint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,16 @@ impl DataPoint {
     pub fn new(time: u64, value: f64) -> Self {
         DataPoint { time, value }
     }
+
+    // Get the time for this DataPoint.
+    pub fn get_time(&self) -> u64 {
+        self.time
+    }
+
+    // Get the value for this DataPoint.
+    pub fn get_value(&self) -> f64 {
+        self.value
+    }
 }
 
 pub mod stream;


### PR DESCRIPTION
Currently, there isn't a way to read the time and value of a DataPoint after it is constructed. This PR adds it so that DataPoint can be inspected outside of this crate.

@jeromefroe - please take a look.