### PR TITLE
Add a derive macro to serialize and deserialize data points

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ keywords = ["time", "series", "compression", "gorilla"]
 nightly = []
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ impl Bit {
 /// DataPoint
 ///
 /// Struct used to represent a single datapoint. Consists of a time and value.
-#[derive(Debug, PartialEq, Copy)]
+#[derive(Debug, PartialEq, Copy, serde::Deserialize, serde::Serialize)]
 pub struct DataPoint {
     time: u64,
     value: f64,


### PR DESCRIPTION
The time series will usually be written to and read from disk. To make this easier, add serialize and deserialize traits to DataPoint.

@jeromefroe - please take a look. And thanks for creating this crate - very helpful.

