### PR TITLE
Implement Ord and PartialOrd traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,8 @@
 //! }
 //! ```
 
+use std::cmp::Ordering;
+
 /// Bit
 ///
 /// An enum used to represent a single bit, can be either `Zero` or `One`.
@@ -126,7 +128,7 @@ impl Bit {
 /// DataPoint
 ///
 /// Struct used to represent a single datapoint. Consists of a time and value.
-#[derive(Debug, PartialEq, Copy, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Copy, serde::Deserialize, serde::Serialize)]
 pub struct DataPoint {
     time: u64,
     value: f64,
@@ -152,6 +154,34 @@ impl DataPoint {
     // Get the value for this DataPoint.
     pub fn get_value(&self) -> f64 {
         self.value
+    }
+}
+
+impl PartialEq for DataPoint {
+    #[inline]
+    fn eq(&self, other: &DataPoint) -> bool {
+        if self.time == other.time {
+            if self.value.is_nan() {
+                return other.value.is_nan();
+            } else {
+                return self.value == other.value;
+            }
+        }
+        false
+    }
+}
+
+impl Eq for DataPoint {}
+
+impl Ord for DataPoint {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.time.cmp(&other.time)
+    }
+}
+
+impl PartialOrd for DataPoint {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,4 +266,22 @@ mod tests {
 
         assert_eq!(original_datapoints, new_datapoints);
     }
+
+    #[test]
+    fn data_point_ordering_test() {
+        let dp_1 = DataPoint::new(20, 2.0);
+        let dp_2 = DataPoint::new(10, 3.0);
+        let dp_3 = DataPoint::new(10, 3.0);
+
+        // The ordering of data points is based on time, so dp_2 will be less than dp_1.
+        assert!(dp_2 < dp_1);
+
+        // Data points are equal if their time and values are equal.
+        assert!(dp_2 == dp_3 && dp_1 != dp_2);
+
+        // Data points with NaN values are equal if their times are equal.
+        let dp_4 = DataPoint::new(10, f64::NAN);
+        let dp_5 = DataPoint::new(10, f64::NAN);
+        assert!(dp_4 == dp_5);
+    }
 }


### PR DESCRIPTION
Enables us to compare DataPoints. Only consider the time dimension for comparison, and most (all?) usecases need time-series data sorted by time values.

@jeromefroe - pl take a look