### PR TITLE
Bug fix - correctly decode the next time when there is a relatively significant jump in the time series

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ nightly = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+test-case = "3.0.0"

--- a/src/decode/std_decoder.rs
+++ b/src/decode/std_decoder.rs
@@ -99,19 +99,16 @@ where
             1 => 7,
             2 => 9,
             3 => 12,
-            4 => {
-                return self.r.read_bits(32).map_err(Error::Stream).and_then(|dod| {
-                    if dod == 0 {
-                        Err(Error::EndOfStream)
-                    } else {
-                        Ok(dod)
-                    }
-                });
-            }
+            4 => 32,
             _ => unreachable!(),
         };
 
         let mut dod = self.r.read_bits(size)?;
+
+        if control_bits == 4 && dod == 0 {
+            // If the control bits are 1111 and delta-of-delta is 0, the stream has ended.
+            return Err(Error::EndOfStream);
+        }
 
         // need to sign extend negative numbers
         if dod > (1 << (size - 1)) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,13 +197,16 @@ pub use self::decode::Decode;
 
 #[cfg(test)]
 mod tests {
+    extern crate test_case;
+
     use std::vec::Vec;
 
     use super::decode::Error;
     use super::stream::{BufferedReader, BufferedWriter};
     use super::{DataPoint, Decode, Encode, StdDecoder, StdEncoder};
 
-    const DATA: &'static str = "1482892270,1.76
+    // A representative time series.
+    const DATA_1: &'static str = "1482892270,1.76
 1482892280,7.78
 1482892288,7.95
 1482892292,5.53
@@ -221,14 +224,20 @@ mod tests {
 1482892800,12908.12
 ";
 
-    #[test]
-    fn integration_test() {
+    // A time series where there is relatively large variation in times.
+    const DATA_2: &'static str = "0,0.0
+1,0.0
+5000,0.0";
+
+    #[test_case::test_case(1482892260, DATA_1 ; "a representative time series")]
+    #[test_case::test_case(0, DATA_2 ; "a time series with relatively large variation in times")]
+    fn integration_test(start_time: u64, data: &str) {
         let w = BufferedWriter::new();
-        let mut encoder = StdEncoder::new(1482892260, w);
+        let mut encoder = StdEncoder::new(start_time, w);
 
         let mut original_datapoints = Vec::new();
 
-        for line in DATA.lines() {
+        for line in data.lines() {
             let substrings: Vec<&str> = line.split(",").collect();
             let t = substrings[0].parse::<u64>().unwrap();
             let v = substrings[1].parse::<f64>().unwrap();


### PR DESCRIPTION
Fix for Issue #9 

When the control sequence was 1111, the previous delta was not getting added to the delta-of-delta. Fixed this and simplified the logic a bit in the process. Also, added a test in lib.rs (along with the test-case crate, so that any similar scenarios in the future can be easily added to the tests).

@jeromefroe - please take a look